### PR TITLE
Add testing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple, clean, and modern web application to help users track pain levels over
 * **Definitions Tab:** Quick reference explaining each pain level from 0-10.
 * **Cross-Device Sync:** All data is stored in Firestore and linked to the user's Google account, making it available on any phone, tablet, or computer.
 * **Responsive Design:** The interface is built with Tailwind CSS to work seamlessly on all screen sizes.
+* **Testing Mode:** Add `?test` to the URL to bypass authentication and store data only in memory.
 
 ## Tech Stack
 
@@ -63,6 +64,7 @@ To deploy your own instance of this application, follow these steps:
 
 ## How to Use
 
+0.  **Testing Mode:** Append `?test` to the URL to try the app without signing in. Data will reset when the page reloads.
 1.  **Sign In:** Open the application and click the "Sign in with Google" button.
 2.  **Add an Entry:** Click the large "+" button at the bottom right to open the entry modal. Select a pain level and click "Save Entry".
 3.  **View History:** Your entries will appear in a list on the "Entries" tab. You can delete an entry using the trash can icon.

--- a/index.html
+++ b/index.html
@@ -157,6 +157,12 @@
         let painChartInstance = null;
         let currentChartPeriod = 'all';
 
+        const testMode = new URLSearchParams(location.search).has('test');
+        const mockEntries = [];
+        let listenForEntries;
+        let saveEntry;
+        let deleteEntry;
+
         // --- DOM Elements ---
         const loginContainer = document.getElementById('login-container');
         const mainContent = document.getElementById('main-content');
@@ -231,37 +237,46 @@
             }
         };
 
-        onAuthStateChanged(auth, (user) => {
-            if (user) {
-                // User is signed in
-                userId = user.uid;
-                loginContainer.classList.add('hidden');
-                mainContent.classList.remove('hidden');
-                authContainer.classList.remove('hidden');
-                addEntryBtnContainer.classList.remove('hidden');
-                userDisplay.textContent = `${user.displayName || 'User'}`;
-                
-                entriesCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/pain_entries`);
-                listenForEntries();
-            } else {
-                // User is signed out
-                userId = null;
-                loginContainer.classList.remove('hidden');
-                mainContent.classList.add('hidden');
-                authContainer.classList.add('hidden');
-                addEntryBtnContainer.classList.add('hidden');
-                
-                if (unsubscribeEntries) {
-                    unsubscribeEntries();
-                    unsubscribeEntries = null;
+        if (!testMode) {
+            onAuthStateChanged(auth, (user) => {
+                if (user) {
+                    // User is signed in
+                    userId = user.uid;
+                    loginContainer.classList.add('hidden');
+                    mainContent.classList.remove('hidden');
+                    authContainer.classList.remove('hidden');
+                    addEntryBtnContainer.classList.remove('hidden');
+                    userDisplay.textContent = `${user.displayName || 'User'}`;
+
+                    entriesCollectionRef = collection(db, `artifacts/${appId}/users/${userId}/pain_entries`);
+                    listenForEntries();
+                } else {
+                    // User is signed out
+                    userId = null;
+                    loginContainer.classList.remove('hidden');
+                    mainContent.classList.add('hidden');
+                    authContainer.classList.add('hidden');
+                    addEntryBtnContainer.classList.add('hidden');
+
+                    if (unsubscribeEntries) {
+                        unsubscribeEntries();
+                        unsubscribeEntries = null;
+                    }
+                    allEntries = [];
+                    renderEntriesList([]);
+                    if (painChartInstance) {
+                        painChartInstance.destroy();
+                    }
                 }
-                allEntries = [];
-                renderEntriesList([]);
-                if (painChartInstance) {
-                    painChartInstance.destroy();
-                }
-            }
-        });
+            });
+        } else {
+            userId = 'test-user';
+            loginContainer.classList.add('hidden');
+            mainContent.classList.remove('hidden');
+            authContainer.classList.add('hidden');
+            addEntryBtnContainer.classList.remove('hidden');
+            listenForEntries();
+        }
 
         // --- Data Rendering (Entries List) ---
         const renderEntriesList = (entries) => {
@@ -328,33 +343,63 @@
             });
         };
 
-        // --- Firestore Logic ---
-        const listenForEntries = () => {
-            if (!entriesCollectionRef) return;
-            if (unsubscribeEntries) unsubscribeEntries();
-            const q = query(entriesCollectionRef);
-            unsubscribeEntries = onSnapshot(q, (snapshot) => {
-                allEntries = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        // --- Data Persistence Logic ---
+        if (testMode) {
+            listenForEntries = () => {
+                allEntries = [...mockEntries];
                 renderEntriesList(allEntries);
                 if (!chartView.classList.contains('hidden')) renderChart();
-            }, (error) => console.error("Firestore listener error:", error));
-        };
-        const saveEntry = async () => {
-            if (!userId || !entriesCollectionRef) return;
-            const newEntry = { painLevel: parseInt(painLevelSlider.value, 10), timestamp: new Date(), userId: userId };
-            try {
-                await addDoc(entriesCollectionRef, newEntry);
+            };
+
+            saveEntry = async () => {
+                const newEntry = {
+                    id: Date.now().toString(),
+                    painLevel: parseInt(painLevelSlider.value, 10),
+                    timestamp: new Date(),
+                    userId
+                };
+                mockEntries.push(newEntry);
                 hideModal();
-            } catch (error) { console.error("Error adding document: ", error); }
-        };
-        const deleteEntry = async (id) => {
-            if (!userId || !entriesCollectionRef) return;
-            if (confirm("Are you sure you want to delete this entry?")) {
+                listenForEntries();
+            };
+
+            deleteEntry = async (id) => {
+                const index = mockEntries.findIndex(e => e.id === id);
+                if (index !== -1) {
+                    mockEntries.splice(index, 1);
+                    listenForEntries();
+                }
+            };
+        } else {
+            listenForEntries = () => {
+                if (!entriesCollectionRef) return;
+                if (unsubscribeEntries) unsubscribeEntries();
+                const q = query(entriesCollectionRef);
+                unsubscribeEntries = onSnapshot(q, (snapshot) => {
+                    allEntries = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                    renderEntriesList(allEntries);
+                    if (!chartView.classList.contains('hidden')) renderChart();
+                }, (error) => console.error("Firestore listener error:", error));
+            };
+
+            saveEntry = async () => {
+                if (!userId || !entriesCollectionRef) return;
+                const newEntry = { painLevel: parseInt(painLevelSlider.value, 10), timestamp: new Date(), userId: userId };
                 try {
-                    await deleteDoc(doc(db, `artifacts/${appId}/users/${userId}/pain_entries`, id));
-                } catch (error) { console.error("Error deleting document: ", error); }
-            }
-        };
+                    await addDoc(entriesCollectionRef, newEntry);
+                    hideModal();
+                } catch (error) { console.error("Error adding document: ", error); }
+            };
+
+            deleteEntry = async (id) => {
+                if (!userId || !entriesCollectionRef) return;
+                if (confirm("Are you sure you want to delete this entry?")) {
+                    try {
+                        await deleteDoc(doc(db, `artifacts/${appId}/users/${userId}/pain_entries`, id));
+                    } catch (error) { console.error("Error deleting document: ", error); }
+                }
+            };
+        }
 
         // --- Event Listeners ---
         signInBtn.addEventListener('click', signInWithGoogle);


### PR DESCRIPTION
## Summary
- add `?test` mode that bypasses Firebase auth and uses an in-memory store
- update documentation with instructions for testing mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe17021088323b4772c35e6f556bf