### PR TITLE
feat: Allow retroactive pain level entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,10 @@
                 <label for="pain-level" class="block text-lg font-medium mb-2">Pain Level: <span id="pain-level-value" class="font-bold text-blue-600 dark:text-blue-400">5</span>/10</label>
                 <input id="pain-level" type="range" min="0" max="10" value="5" class="w-full h-3 bg-gray-200 dark:bg-gray-700 rounded-lg appearance-none cursor-pointer">
             </div>
+            <div class="mb-6">
+                <label for="entry-datetime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Date and Time</label>
+                <input type="datetime-local" id="entry-datetime" name="entry-datetime" class="mt-1 block w-full px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+            </div>
             <div class="flex justify-end space-x-4">
                 <button id="cancel-btn" class="px-6 py-2 rounded-lg text-gray-700 dark:text-gray-300 bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors">Cancel</button>
                 <button id="save-btn" class="px-6 py-2 rounded-lg text-white bg-blue-600 hover:bg-blue-700 transition-colors">Save Entry</button>
@@ -270,11 +274,15 @@
                 entriesList.innerHTML = `<div class="text-center py-10 px-4"><svg xmlns="http://www.w3.org/2000/svg" class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg><h3 class="mt-2 text-lg font-medium text-gray-900 dark:text-gray-200">No entries yet</h3><p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Tap the '+' button to add your first pain level entry.</p></div>`;
                 return;
             }
-            const sortedEntries = [...entries].sort((a, b) => b.timestamp.toMillis() - a.timestamp.toMillis());
+            const sortedEntries = [...entries].sort((a, b) => {
+                const dateA = a.timestamp.toDate ? a.timestamp.toDate() : new Date(a.timestamp);
+                const dateB = b.timestamp.toDate ? b.timestamp.toDate() : new Date(b.timestamp);
+                return dateB - dateA;
+            });
             sortedEntries.forEach(entry => {
                 const entryEl = document.createElement('div');
                 entryEl.className = 'bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 flex items-center justify-between';
-                const date = entry.timestamp.toDate();
+                const date = entry.timestamp.toDate ? entry.timestamp.toDate() : new Date(entry.timestamp);
                 const formattedDate = date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
                 const formattedTime = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
                 entryEl.innerHTML = `<div><p class="font-bold text-lg">Pain Level: <span class="text-blue-600 dark:text-blue-400">${entry.painLevel}</span></p><p class="text-sm text-gray-500 dark:text-gray-400">${formattedDate} at ${formattedTime}</p></div><button data-id="${entry.id}" class="delete-btn text-gray-400 hover:text-red-500 transition-colors p-2 rounded-full"><svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg></button>`;
@@ -290,7 +298,7 @@
                 const days = parseInt(currentChartPeriod);
                 const cutoffDate = new Date();
                 cutoffDate.setDate(cutoffDate.getDate() - days);
-                filteredEntries = allEntries.filter(entry => entry.timestamp.toDate() > cutoffDate);
+                filteredEntries = allEntries.filter(entry => (entry.timestamp.toDate ? entry.timestamp.toDate() : new Date(entry.timestamp)) > cutoffDate);
             }
             if (filteredEntries.length < 2) {
                 chartCanvas.classList.add('hidden');
@@ -299,9 +307,13 @@
             }
             chartCanvas.classList.remove('hidden');
             chartEmptyState.classList.add('hidden');
-            const sortedEntries = [...filteredEntries].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
+            const sortedEntries = [...filteredEntries].sort((a, b) => {
+                const dateA = a.timestamp.toDate ? a.timestamp.toDate() : new Date(a.timestamp);
+                const dateB = b.timestamp.toDate ? b.timestamp.toDate() : new Date(b.timestamp);
+                return dateA - dateB;
+            });
             const chartData = {
-                labels: sortedEntries.map(entry => entry.timestamp.toDate()),
+                labels: sortedEntries.map(entry => entry.timestamp.toDate ? entry.timestamp.toDate() : new Date(entry.timestamp)),
                 datasets: [{
                     label: 'Pain Level',
                     data: sortedEntries.map(entry => entry.painLevel),
@@ -341,11 +353,41 @@
         };
         const saveEntry = async () => {
             if (!userId || !entriesCollectionRef) return;
-            const newEntry = { painLevel: parseInt(painLevelSlider.value, 10), timestamp: new Date(), userId: userId };
+
+            const entryDatetime = document.getElementById('entry-datetime');
+            let timestamp;
+
+            if (entryDatetime.value) {
+                const selectedDate = new Date(entryDatetime.value);
+                const now = new Date();
+                const twentyFourHoursAgo = new Date(now.getTime() - (24 * 60 * 60 * 1000));
+
+                if (selectedDate > now) {
+                    alert("You cannot select a future date.");
+                    return;
+                }
+                if (selectedDate < twentyFourHoursAgo) {
+                    alert("You can only select a date up to 24 hours in the past.");
+                    return;
+                }
+                timestamp = selectedDate;
+            } else {
+                timestamp = new Date();
+            }
+
+            const newEntry = {
+                painLevel: parseInt(painLevelSlider.value, 10),
+                timestamp: timestamp,
+                userId: userId
+            };
+
             try {
                 await addDoc(entriesCollectionRef, newEntry);
                 hideModal();
-            } catch (error) { console.error("Error adding document: ", error); }
+                entryDatetime.value = ''; // Reset the input field
+            } catch (error) {
+                console.error("Error adding document: ", error);
+            }
         };
         const deleteEntry = async (id) => {
             if (!userId || !entriesCollectionRef) return;


### PR DESCRIPTION
This commit introduces the ability for you to retroactively add pain level entries up to 24 hours in the past.

Key changes:
- Added a datetime-local input field to the new entry modal.
- Modified the saveEntry function to handle the new input. If a date is selected, it is used as the timestamp for the new entry. Otherwise, the current time is used.
- Implemented validation to ensure that the selected date is not in the future and is within the last 24 hours.
- Updated the entry list and chart to correctly sort and display entries with both Firestore Timestamps and JavaScript Date objects.