### PR TITLE
feat: Add data export to CSV feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,14 @@
             <main>
                 <!-- Entries View -->
                 <div id="entries-view">
+                    <div class="flex justify-end mb-4">
+                        <button id="export-csv-btn" class="px-4 py-2 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition-colors flex items-center">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                            </svg>
+                            Export to CSV
+                        </button>
+                    </div>
                     <div id="entries-list" class="space-y-4"></div>
                 </div>
 

--- a/script.js
+++ b/script.js
@@ -47,6 +47,7 @@ const definitionsView = document.getElementById('definitions-view');
 const chartCanvas = document.getElementById('painChart');
 const chartEmptyState = document.getElementById('chart-empty-state');
 const timeFilterButtons = document.querySelectorAll('.time-filter-btn');
+const exportCsvBtn = document.getElementById('export-csv-btn');
 
 // --- Modal Logic ---
 const showModal = () => entryModal.classList.replace('modal-hidden', 'modal-visible');
@@ -222,7 +223,41 @@ const deleteEntry = async (id) => {
     }
 };
 
+// --- Data Export ---
+const exportDataToCSV = () => {
+    if (allEntries.length === 0) {
+        alert("No data to export.");
+        return;
+    }
+
+    // Sort entries chronologically
+    const sortedEntries = [...allEntries].sort((a, b) => a.timestamp.toMillis() - b.timestamp.toMillis());
+
+    // CSV Header
+    let csvContent = "data:text/csv;charset=utf-8,";
+    csvContent += "Timestamp,Pain Level\r\n";
+
+    // CSV Rows
+    sortedEntries.forEach(entry => {
+        const date = entry.timestamp.toDate();
+        // Format to ISO 8601 for universal compatibility
+        const formattedTimestamp = date.toISOString();
+        const row = `${formattedTimestamp},${entry.painLevel}`;
+        csvContent += row + "\r\n";
+    });
+
+    // Create a link and trigger the download
+    const encodedUri = encodeURI(csvContent);
+    const link = document.createElement("a");
+    link.setAttribute("href", encodedUri);
+    link.setAttribute("download", "pain_entries.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};
+
 // --- Event Listeners ---
+exportCsvBtn.addEventListener('click', exportDataToCSV);
 signInBtn.addEventListener('click', signInWithGoogle);
 signOutBtn.addEventListener('click', signOutUser);
 addEntryBtn.addEventListener('click', showModal);


### PR DESCRIPTION
This commit introduces a new feature that allows you to export your pain tracking data to a CSV file.

- Adds an "Export to CSV" button to the "Entries" tab in `index.html`.
- Implements the `exportDataToCSV` function in `script.js` to convert your data into a CSV format and trigger a download.
- The exported CSV includes a header row and columns for "Timestamp" (in ISO 8601 format) and "Pain Level".
- Connects the new button to the export function using an event listener.