### PR TITLE
feat: Prototype pain map feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,6 +120,12 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="mt-8">
+                            <h3 class="text-xl font-bold mb-4 text-blue-600 dark:text-blue-400">Pain Map History</h3>
+                            <div id="pain-map-history-list" class="space-y-4">
+                                <!-- Historical pain map entries will be rendered here -->
+                            </div>
+                        </div>
                     </div>
                 </div>
             </main>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="pain-map.css">
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
 
@@ -41,6 +42,7 @@
                     <nav class="-mb-px flex space-x-6" aria-label="Tabs">
                         <button id="entries-tab" class="tab-btn px-3 py-2 text-sm font-medium rounded-t-md text-gray-600 dark:text-gray-300 border-b-2 border-transparent bg-white dark:bg-gray-800 tab-active">Entries</button>
                         <button id="chart-tab" class="tab-btn px-3 py-2 text-sm font-medium rounded-t-md text-gray-600 dark:text-gray-300 border-b-2 border-transparent bg-white dark:bg-gray-800">Chart</button>
+                        <button id="pain-map-tab" class="tab-btn px-3 py-2 text-sm font-medium rounded-t-md text-gray-600 dark:text-gray-300 border-b-2 border-transparent bg-white dark:bg-gray-800">Pain Map</button>
                         <button id="definitions-tab" class="tab-btn px-3 py-2 text-sm font-medium rounded-t-md text-gray-600 dark:text-gray-300 border-b-2 border-transparent bg-white dark:bg-gray-800">Definitions</button>
                     </nav>
                 </div>
@@ -92,6 +94,34 @@
                         </ul>
                     </div>
                 </div>
+
+                <!-- Pain Map View -->
+                <div id="pain-map-view" class="hidden">
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4">
+                        <div class="flex flex-col md:flex-row gap-8">
+                            <!-- Left side: Image -->
+                            <div class="md:w-1/2">
+                                <h2 class="text-xl font-bold mb-4 text-blue-600 dark:text-blue-400">Pain Map</h2>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Click on the dots to select a pain location and set a pain level.</p>
+                                <div id="pain-map-image-container" class="relative w-full max-w-sm mx-auto">
+                                    <img src="images/upper-body-posterior-view.png" alt="Outline of a person's back and shoulders" class="w-full h-auto rounded-md bg-gray-200 dark:bg-gray-700">
+                                    <!-- Pain points will be injected here by pain-map.js -->
+                                </div>
+                            </div>
+                            <!-- Right side: List and controls -->
+                            <div class="md:w-1/2">
+                                <h3 class="text-lg font-semibold mb-4">Selected Locations</h3>
+                                <div id="pain-locations-list" class="space-y-3 mb-6">
+                                    <!-- Selected locations will be listed here by pain-map.js -->
+                                    <p class="text-gray-500 dark:text-gray-400">No locations selected yet.</p>
+                                </div>
+                                <div class="flex justify-end">
+                                    <button id="save-pain-map-btn" class="px-6 py-2 rounded-lg text-white bg-blue-600 hover:bg-blue-700 transition-colors">Save Pain Map</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </main>
         </div>
     </div>
@@ -123,5 +153,6 @@
     </div>
 
     <script src="script.js" type="module"></script>
+    <script src="pain-map.js" type="module"></script>
 </body>
 </html>

--- a/pain-locations.js
+++ b/pain-locations.js
@@ -1,22 +1,22 @@
 export const painLocations = [
     // 1. Neck and upper shoulder (Upper Trapezius and Levator Scapulae)
-    { id: 'neck_upper_shoulder_left', name: 'Neck/Upper Shoulder', coords: { x: 42, y: 20 } },
+    { id: 'neck_upper_shoulder_left', name: 'Left Neck/Upper Shoulder', coords: { x: 40, y: 25 } },
 
     // 2. Along the Spine (Rhomboids and Middle Trapezius)
-    { id: 'along_spine_left', name: 'Upper Scapula along Spine', coords: { x: 45, y: 34 } },
+    { id: 'along_spine_left', name: 'Left side along Spine', coords: { x: 45, y: 40 } },
 
     // 3. Inferior angle of the scapula and Latissimus Dorsi
-    { id: 'inferior_angle_scapula_left', name: 'Inferior Angle of Scapula/Lats', coords: { x: 42, y: 55 } },
+    { id: 'inferior_angle_scapula_left', name: 'Left Inferior Angle of Scapula/Lats', coords: { x: 42, y: 55 } },
 
     // 4. Outer of the Shoulder (Deltoid Muscle)
-    { id: 'deltoid_left', name: 'Outer Deltoid', coords: { x: 20, y: 35 } },
+    { id: 'deltoid_left', name: 'Left Deltoid', coords: { x: 30, y: 35 } },
 
     // 5. Back bottom of the Shoulder (Teres Muscles)
-    { id: 'teres_left', name: 'Teres Muscles', coords: { x: 28, y: 50 } },
+    { id: 'teres_left', name: 'Left Teres Muscles', coords: { x: 35, y: 48 } },
 
     // 6. Top of the Shoulder Blade (Supraspinatus)
-    { id: 'supraspinatus_left', name: 'Supraspinatus', coords: { x: 32, y: 28 } },
+    { id: 'supraspinatus_left', name: 'Left Supraspinatus', coords: { x: 38, y: 32 } },
 
     // 7. Radiating Pain Down the Arm
-    { id: 'arm_radiation_left', name: 'Radiating Pain Down Arm', coords: { x: 10, y: 70 } },
+    { id: 'arm_radiation_left', name: 'Radiating Pain Down Left Arm', coords: { x: 25, y: 60 } },
 ];

--- a/pain-locations.js
+++ b/pain-locations.js
@@ -1,22 +1,22 @@
 export const painLocations = [
     // 1. Neck and upper shoulder (Upper Trapezius and Levator Scapulae)
-    { id: 'neck_upper_shoulder_left', name: 'Left Neck/Upper Shoulder', coords: { x: 40, y: 25 } },
+    { id: 'neck_upper_shoulder_left', name: 'Neck/Upper Shoulder', coords: { x: 42, y: 20 } },
 
     // 2. Along the Spine (Rhomboids and Middle Trapezius)
-    { id: 'along_spine_left', name: 'Left side along Spine', coords: { x: 45, y: 40 } },
+    { id: 'along_spine_left', name: 'Upper Scapula along Spine', coords: { x: 45, y: 34 } },
 
     // 3. Inferior angle of the scapula and Latissimus Dorsi
-    { id: 'inferior_angle_scapula_left', name: 'Left Inferior Angle of Scapula/Lats', coords: { x: 42, y: 55 } },
+    { id: 'inferior_angle_scapula_left', name: 'Inferior Angle of Scapula/Lats', coords: { x: 42, y: 55 } },
 
     // 4. Outer of the Shoulder (Deltoid Muscle)
-    { id: 'deltoid_left', name: 'Left Deltoid', coords: { x: 30, y: 35 } },
+    { id: 'deltoid_left', name: 'Outer Deltoid', coords: { x: 20, y: 35 } },
 
     // 5. Back bottom of the Shoulder (Teres Muscles)
-    { id: 'teres_left', name: 'Left Teres Muscles', coords: { x: 35, y: 48 } },
+    { id: 'teres_left', name: 'Teres Muscles', coords: { x: 28, y: 50 } },
 
     // 6. Top of the Shoulder Blade (Supraspinatus)
-    { id: 'supraspinatus_left', name: 'Left Supraspinatus', coords: { x: 38, y: 32 } },
+    { id: 'supraspinatus_left', name: 'Supraspinatus', coords: { x: 32, y: 28 } },
 
     // 7. Radiating Pain Down the Arm
-    { id: 'arm_radiation_left', name: 'Radiating Pain Down Left Arm', coords: { x: 25, y: 60 } },
+    { id: 'arm_radiation_left', name: 'Radiating Pain Down Arm', coords: { x: 10, y: 70 } },
 ];

--- a/pain-locations.js
+++ b/pain-locations.js
@@ -1,0 +1,29 @@
+export const painLocations = [
+    // 1. Neck and upper shoulder (Upper Trapezius and Levator Scapulae)
+    { id: 'neck_upper_shoulder_left', name: 'Left Neck/Upper Shoulder', coords: { x: 40, y: 25 } },
+    { id: 'neck_upper_shoulder_right', name: 'Right Neck/Upper Shoulder', coords: { x: 60, y: 25 } },
+
+    // 2. Along the Spine (Rhomboids and Middle Trapezius)
+    { id: 'along_spine_left', name: 'Left side along Spine', coords: { x: 45, y: 40 } },
+    { id: 'along_spine_right', name: 'Right side along Spine', coords: { x: 55, y: 40 } },
+
+    // 3. Inferior angle of the scapula and Latissimus Dorsi
+    { id: 'inferior_angle_scapula_left', name: 'Left Inferior Angle of Scapula/Lats', coords: { x: 42, y: 55 } },
+    { id: 'inferior_angle_scapula_right', name: 'Right Inferior Angle of Scapula/Lats', coords: { x: 58, y: 55 } },
+
+    // 4. Outer of the Shoulder (Deltoid Muscle)
+    { id: 'deltoid_left', name: 'Left Deltoid', coords: { x: 30, y: 35 } },
+    { id: 'deltoid_right', name: 'Right Deltoid', coords: { x: 70, y: 35 } },
+
+    // 5. Back bottom of the Shoulder (Teres Muscles)
+    { id: 'teres_left', name: 'Left Teres Muscles', coords: { x: 35, y: 48 } },
+    { id: 'teres_right', name: 'Right Teres Muscles', coords: { x: 65, y: 48 } },
+
+    // 6. Top of the Shoulder Blade (Supraspinatus)
+    { id: 'supraspinatus_left', name: 'Left Supraspinatus', coords: { x: 38, y: 32 } },
+    { id: 'supraspinatus_right', name: 'Right Supraspinatus', coords: { x: 62, y: 32 } },
+
+    // 7. Radiating Pain Down the Arm
+    { id: 'arm_radiation_left', name: 'Radiating Pain Down Left Arm', coords: { x: 25, y: 60 } },
+    { id: 'arm_radiation_right', name: 'Radiating Pain Down Right Arm', coords: { x: 75, y: 60 } },
+];

--- a/pain-locations.js
+++ b/pain-locations.js
@@ -1,29 +1,22 @@
 export const painLocations = [
     // 1. Neck and upper shoulder (Upper Trapezius and Levator Scapulae)
     { id: 'neck_upper_shoulder_left', name: 'Left Neck/Upper Shoulder', coords: { x: 40, y: 25 } },
-    { id: 'neck_upper_shoulder_right', name: 'Right Neck/Upper Shoulder', coords: { x: 60, y: 25 } },
 
     // 2. Along the Spine (Rhomboids and Middle Trapezius)
     { id: 'along_spine_left', name: 'Left side along Spine', coords: { x: 45, y: 40 } },
-    { id: 'along_spine_right', name: 'Right side along Spine', coords: { x: 55, y: 40 } },
 
     // 3. Inferior angle of the scapula and Latissimus Dorsi
     { id: 'inferior_angle_scapula_left', name: 'Left Inferior Angle of Scapula/Lats', coords: { x: 42, y: 55 } },
-    { id: 'inferior_angle_scapula_right', name: 'Right Inferior Angle of Scapula/Lats', coords: { x: 58, y: 55 } },
 
     // 4. Outer of the Shoulder (Deltoid Muscle)
     { id: 'deltoid_left', name: 'Left Deltoid', coords: { x: 30, y: 35 } },
-    { id: 'deltoid_right', name: 'Right Deltoid', coords: { x: 70, y: 35 } },
 
     // 5. Back bottom of the Shoulder (Teres Muscles)
     { id: 'teres_left', name: 'Left Teres Muscles', coords: { x: 35, y: 48 } },
-    { id: 'teres_right', name: 'Right Teres Muscles', coords: { x: 65, y: 48 } },
 
     // 6. Top of the Shoulder Blade (Supraspinatus)
     { id: 'supraspinatus_left', name: 'Left Supraspinatus', coords: { x: 38, y: 32 } },
-    { id: 'supraspinatus_right', name: 'Right Supraspinatus', coords: { x: 62, y: 32 } },
 
     // 7. Radiating Pain Down the Arm
     { id: 'arm_radiation_left', name: 'Radiating Pain Down Left Arm', coords: { x: 25, y: 60 } },
-    { id: 'arm_radiation_right', name: 'Radiating Pain Down Right Arm', coords: { x: 75, y: 60 } },
 ];

--- a/pain-map.css
+++ b/pain-map.css
@@ -1,0 +1,75 @@
+.pain-point {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background-color: rgba(0, 119, 255, 0.6);
+    border: 2px solid white;
+    cursor: pointer;
+    transition: all 0.2s ease-in-out;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.pain-point:hover {
+    transform: translate(-50%, -50%) scale(1.2);
+    background-color: rgba(0, 119, 255, 0.9);
+}
+
+.pain-point.selected {
+    background-color: rgba(255, 0, 0, 0.8);
+    border-color: #fff;
+    box-shadow: 0 0 10px rgba(255, 0, 0, 0.9);
+}
+
+.selected-location-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #f9fafb; /* bg-gray-50 */
+    padding: 0.5rem; /* p-2 */
+    border-radius: 0.375rem; /* rounded-md */
+}
+
+.dark .selected-location-item {
+    background-color: #374151; /* dark:bg-gray-700 */
+}
+
+/* Customizing the range slider */
+.pain-level-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 8px;
+    border-radius: 5px;
+    background: #d1d5db; /* bg-gray-300 */
+    outline: none;
+    opacity: 0.7;
+    transition: opacity .2s;
+}
+
+.dark .pain-level-slider {
+    background: #4b5563; /* dark:bg-gray-600 */
+}
+
+.pain-level-slider:hover {
+    opacity: 1;
+}
+
+.pain-level-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #3b82f6; /* bg-blue-600 */
+    cursor: pointer;
+}
+
+.pain-level-slider::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #3b82f6; /* bg-blue-600 */
+    cursor: pointer;
+}

--- a/pain-map.js
+++ b/pain-map.js
@@ -1,0 +1,138 @@
+import { collection, addDoc, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
+import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
+import { db, auth } from './script.js';
+import { painLocations } from './pain-locations.js';
+
+const painMapImageContainer = document.getElementById('pain-map-image-container');
+const painLocationsList = document.getElementById('pain-locations-list');
+const savePainMapBtn = document.getElementById('save-pain-map-btn');
+
+let currentUserId = null;
+let selectedLocations = {}; // Use an object for easier lookup
+
+onAuthStateChanged(auth, (user) => {
+    currentUserId = user ? user.uid : null;
+});
+
+const renderPainPoints = () => {
+    if (!painMapImageContainer) return;
+    painLocations.forEach(location => {
+        const dot = document.createElement('div');
+        dot.className = 'pain-point';
+        dot.style.left = `${location.coords.x}%`;
+        dot.style.top = `${location.coords.y}%`;
+        dot.dataset.id = location.id;
+        dot.setAttribute('title', location.name);
+
+        dot.addEventListener('click', () => toggleLocationSelection(location));
+        painMapImageContainer.appendChild(dot);
+    });
+};
+
+const toggleLocationSelection = (location) => {
+    const dot = painMapImageContainer.querySelector(`.pain-point[data-id="${location.id}"]`);
+    if (selectedLocations[location.id]) {
+        // Deselect
+        delete selectedLocations[location.id];
+        dot.classList.remove('selected');
+    } else {
+        // Select
+        selectedLocations[location.id] = { ...location, painLevel: 5 }; // Default pain level
+        dot.classList.add('selected');
+    }
+    renderSelectedLocationsList();
+};
+
+const renderSelectedLocationsList = () => {
+    if (!painLocationsList) return;
+    painLocationsList.innerHTML = '';
+    const selectedIds = Object.keys(selectedLocations);
+
+    if (selectedIds.length === 0) {
+        painLocationsList.innerHTML = '<p class="text-gray-500 dark:text-gray-400">No locations selected yet.</p>';
+        return;
+    }
+
+    selectedIds.forEach(id => {
+        const location = selectedLocations[id];
+        const listItem = document.createElement('div');
+        listItem.className = 'selected-location-item flex justify-between items-center bg-gray-50 dark:bg-gray-700 p-2 rounded-md';
+        listItem.innerHTML = `
+            <div class="flex-grow pr-4">
+                <p class="font-semibold">${location.name}</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Pain Level: <span id="level-value-${id}">${location.painLevel}</span>/10</p>
+            </div>
+            <div class="flex items-center">
+                 <input type="range" min="0" max="10" value="${location.painLevel}" data-id="${id}" class="w-24 h-2 bg-gray-200 dark:bg-gray-600 rounded-lg appearance-none cursor-pointer pain-level-slider">
+            </div>
+        `;
+        painLocationsList.appendChild(listItem);
+    });
+};
+
+if (painLocationsList) {
+    painLocationsList.addEventListener('input', (e) => {
+        if (e.target.classList.contains('pain-level-slider')) {
+            const locationId = e.target.dataset.id;
+            const newPainLevel = parseInt(e.target.value, 10);
+            selectedLocations[locationId].painLevel = newPainLevel;
+            document.getElementById(`level-value-${locationId}`).textContent = newPainLevel;
+        }
+    });
+}
+
+
+const savePainMap = async () => {
+    if (!currentUserId) {
+        alert("You must be logged in to save a pain map.");
+        return;
+    }
+    if (Object.keys(selectedLocations).length === 0) {
+        alert("Please select at least one pain location and set its level.");
+        return;
+    }
+
+    const painMapEntry = {
+        userId: currentUserId,
+        timestamp: serverTimestamp(),
+        locations: Object.values(selectedLocations).map(loc => ({
+            id: loc.id,
+            name: loc.name,
+            painLevel: loc.painLevel
+        })),
+    };
+
+    try {
+        const appId = typeof __app_id !== 'undefined' ? __app_id : 'shoulder-pain-tracker';
+        const painMapsCollectionRef = collection(db, `artifacts/${appId}/users/${currentUserId}/pain_maps`);
+        await addDoc(painMapsCollectionRef, painMapEntry);
+        alert("Pain map saved successfully!");
+        // Reset selection
+        selectedLocations = {};
+        document.querySelectorAll('.pain-point.selected').forEach(dot => dot.classList.remove('selected'));
+        renderSelectedLocationsList();
+    } catch (error) {
+        console.error("Error saving pain map: ", error);
+        alert("Failed to save pain map. Please try again.");
+    }
+};
+
+// --- Initialization ---
+// This runs when the script is loaded.
+// We need to make sure the DOM is fully loaded before we try to access elements.
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        renderPainPoints();
+        renderSelectedLocationsList();
+        if (savePainMapBtn) {
+            savePainMapBtn.addEventListener('click', savePainMap);
+        }
+    });
+} else {
+    // DOMContentLoaded has already fired
+    renderPainPoints();
+    renderSelectedLocationsList();
+    if (savePainMapBtn) {
+        savePainMapBtn.addEventListener('click', savePainMap);
+    }
+}

--- a/script.js
+++ b/script.js
@@ -13,8 +13,8 @@ const firebaseConfig = {
 };
 const appId = typeof __app_id !== 'undefined' ? __app_id : 'shoulder-pain-tracker';
 const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+export const auth = getAuth(app);
+export const db = getFirestore(app);
 
 let userId = null;
 let entriesCollectionRef = null;
@@ -41,9 +41,11 @@ const entriesList = document.getElementById('entries-list');
 const entriesTab = document.getElementById('entries-tab');
 const chartTab = document.getElementById('chart-tab');
 const definitionsTab = document.getElementById('definitions-tab');
+const painMapTab = document.getElementById('pain-map-tab');
 const entriesView = document.getElementById('entries-view');
 const chartView = document.getElementById('chart-view');
 const definitionsView = document.getElementById('definitions-view');
+const painMapView = document.getElementById('pain-map-view');
 const chartCanvas = document.getElementById('painChart');
 const chartEmptyState = document.getElementById('chart-empty-state');
 const timeFilterButtons = document.querySelectorAll('.time-filter-btn');
@@ -71,7 +73,8 @@ const switchTab = (targetTab) => {
     const tabs = [
         { button: entriesTab, view: entriesView },
         { button: chartTab, view: chartView },
-        { button: definitionsTab, view: definitionsView }
+        { button: definitionsTab, view: definitionsView },
+        { button: painMapTab, view: painMapView }
     ];
 
     // Loop through all tabs
@@ -290,6 +293,7 @@ painLevelSlider.addEventListener('input', (e) => painLevelValue.textContent = e.
 entriesTab.addEventListener('click', () => switchTab('entries'));
 chartTab.addEventListener('click', () => switchTab('chart'));
 definitionsTab.addEventListener('click', () => switchTab('definitions'));
+painMapTab.addEventListener('click', () => switchTab('pain-map'));
 entriesList.addEventListener('click', (e) => {
     const deleteButton = e.target.closest('.delete-btn');
     if (deleteButton) deleteEntry(deleteButton.dataset.id);


### PR DESCRIPTION
This commit introduces a prototype for a new "Pain Map" feature. It adds a new tab to the application where users can visually identify and record pain levels for specific, predefined locations on an image of the upper body.

Key changes:
- Added a "Pain Map" tab and view to `index.html`.
- Created `pain-map.js` to handle the logic for rendering pain points, user interaction (selecting locations, setting pain levels), and saving the data to a new `pain_maps` collection in Firestore.
- Created `pain-locations.js` to define the coordinates and names for the 14 discrete pain locations.
- Added `pain-map.css` for styling the new UI elements.
- Updated `script.js` to handle tab switching for the new view and to export Firebase instances for use in other modules.